### PR TITLE
Improve internal server error diagnostics

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -983,14 +983,18 @@ components:
 
     InternalProblem:
       description: |
-        A deliberately impoverished internal failure. Wrapped causes,
-        locations, execution context, catalog identity, keys, and values are
-        never exposed. `incident` is an optional opaque log correlation ID.
+        A database failure that prevents the operation from completing. The
+        detail contains the complete available diagnostic, including wrapped
+        causes. `incident` correlates the response with the server log.
       allOf:
         - $ref: "#/components/schemas/ProblemBase"
         - type: object
-          required: [code]
+          required: [code, detail]
           properties:
+            detail:
+              description: The complete available diagnostic for this failure.
+              type: string
+              minLength: 1
             type:
               type: string
               enum: ["urn:rad:problem:internal"]
@@ -1005,9 +1009,16 @@ components:
               enum: [internal]
             reason:
               type: string
-              enum: [internal]
+              enum:
+                - internal
+                - commit_outcome_unknown
+                - catalog_corrupt
+                - catalog_schema_drift
+                - storage_unavailable
+            stage:
+              $ref: "#/components/schemas/ProblemStage"
             incident:
-              description: An opaque identifier correlated with server-side diagnostics.
+              description: An identifier correlated with the server log.
               type: string
 
     Value:

--- a/clients/go/api/oas/oas_json_gen.go
+++ b/clients/go/api/oas/oas_json_gen.go
@@ -3306,10 +3306,8 @@ func (s *InternalProblem) encodeFields(e *jx.Encoder) {
 		s.Status.Encode(e)
 	}
 	{
-		if s.Detail.Set {
-			e.FieldStart("detail")
-			s.Detail.Encode(e)
-		}
+		e.FieldStart("detail")
+		e.Str(s.Detail)
 	}
 	{
 		e.FieldStart("reason")
@@ -3320,6 +3318,12 @@ func (s *InternalProblem) encodeFields(e *jx.Encoder) {
 		s.Code.Encode(e)
 	}
 	{
+		if s.Stage.Set {
+			e.FieldStart("stage")
+			s.Stage.Encode(e)
+		}
+	}
+	{
 		if s.Incident.Set {
 			e.FieldStart("incident")
 			s.Incident.Encode(e)
@@ -3327,14 +3331,15 @@ func (s *InternalProblem) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfInternalProblem = [7]string{
+var jsonFieldsNameOfInternalProblem = [8]string{
 	0: "type",
 	1: "title",
 	2: "status",
 	3: "detail",
 	4: "reason",
 	5: "code",
-	6: "incident",
+	6: "stage",
+	7: "incident",
 }
 
 // Decode decodes InternalProblem from json.
@@ -3377,9 +3382,11 @@ func (s *InternalProblem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
 		case "detail":
+			requiredBitSet[0] |= 1 << 3
 			if err := func() error {
-				s.Detail.Reset()
-				if err := s.Detail.Decode(d); err != nil {
+				v, err := d.Str()
+				s.Detail = string(v)
+				if err != nil {
 					return err
 				}
 				return nil
@@ -3406,6 +3413,16 @@ func (s *InternalProblem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"code\"")
 			}
+		case "stage":
+			if err := func() error {
+				s.Stage.Reset()
+				if err := s.Stage.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"stage\"")
+			}
 		case "incident":
 			if err := func() error {
 				s.Incident.Reset()
@@ -3426,7 +3443,7 @@ func (s *InternalProblem) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00110111,
+		0b00111111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -3528,6 +3545,14 @@ func (s *InternalProblemReason) Decode(d *jx.Decoder) error {
 	switch InternalProblemReason(v) {
 	case InternalProblemReasonInternal:
 		*s = InternalProblemReasonInternal
+	case InternalProblemReasonCommitOutcomeUnknown:
+		*s = InternalProblemReasonCommitOutcomeUnknown
+	case InternalProblemReasonCatalogCorrupt:
+		*s = InternalProblemReasonCatalogCorrupt
+	case InternalProblemReasonCatalogSchemaDrift:
+		*s = InternalProblemReasonCatalogSchemaDrift
+	case InternalProblemReasonStorageUnavailable:
+		*s = InternalProblemReasonStorageUnavailable
 	default:
 		*s = InternalProblemReason(v)
 	}
@@ -4889,6 +4914,39 @@ func (s *OptProblemLocation) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes ProblemStage as json.
+func (o OptProblemStage) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Str(string(o.Value))
+}
+
+// Decode decodes ProblemStage from json.
+func (o *OptProblemStage) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptProblemStage to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptProblemStage) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptProblemStage) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes ResourceContext as json.
 func (o OptResourceContext) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -5644,14 +5702,18 @@ func (s Problem) encodeFields(e *jx.Encoder) {
 				s.Status.Encode(e)
 			}
 			{
-				if s.Detail.Set {
-					e.FieldStart("detail")
-					s.Detail.Encode(e)
-				}
+				e.FieldStart("detail")
+				e.Str(s.Detail)
 			}
 			{
 				e.FieldStart("reason")
 				s.Reason.Encode(e)
+			}
+			{
+				if s.Stage.Set {
+					e.FieldStart("stage")
+					s.Stage.Encode(e)
+				}
 			}
 			{
 				if s.Incident.Set {

--- a/clients/go/api/oas/oas_schemas_gen.go
+++ b/clients/go/api/oas/oas_schemas_gen.go
@@ -1280,12 +1280,13 @@ type InternalProblem struct {
 	Title InternalProblemTitle `json:"title"`
 	// Merged property.
 	Status InternalProblemStatus `json:"status"`
-	// A human readable explanation specific to this occurrence.
-	Detail OptString `json:"detail"`
+	// Merged property.
+	Detail string `json:"detail"`
 	// Merged property.
 	Reason InternalProblemReason `json:"reason"`
 	Code   InternalProblemCode   `json:"code"`
-	// An opaque identifier correlated with server-side diagnostics.
+	Stage  OptProblemStage       `json:"stage"`
+	// An identifier correlated with the server log.
 	Incident OptString `json:"incident"`
 }
 
@@ -1305,7 +1306,7 @@ func (s *InternalProblem) GetStatus() InternalProblemStatus {
 }
 
 // GetDetail returns the value of Detail.
-func (s *InternalProblem) GetDetail() OptString {
+func (s *InternalProblem) GetDetail() string {
 	return s.Detail
 }
 
@@ -1317,6 +1318,11 @@ func (s *InternalProblem) GetReason() InternalProblemReason {
 // GetCode returns the value of Code.
 func (s *InternalProblem) GetCode() InternalProblemCode {
 	return s.Code
+}
+
+// GetStage returns the value of Stage.
+func (s *InternalProblem) GetStage() OptProblemStage {
+	return s.Stage
 }
 
 // GetIncident returns the value of Incident.
@@ -1340,7 +1346,7 @@ func (s *InternalProblem) SetStatus(val InternalProblemStatus) {
 }
 
 // SetDetail sets the value of Detail.
-func (s *InternalProblem) SetDetail(val OptString) {
+func (s *InternalProblem) SetDetail(val string) {
 	s.Detail = val
 }
 
@@ -1352,6 +1358,11 @@ func (s *InternalProblem) SetReason(val InternalProblemReason) {
 // SetCode sets the value of Code.
 func (s *InternalProblem) SetCode(val InternalProblemCode) {
 	s.Code = val
+}
+
+// SetStage sets the value of Stage.
+func (s *InternalProblem) SetStage(val OptProblemStage) {
+	s.Stage = val
 }
 
 // SetIncident sets the value of Incident.
@@ -1397,13 +1408,21 @@ func (s *InternalProblemCode) UnmarshalText(data []byte) error {
 type InternalProblemReason string
 
 const (
-	InternalProblemReasonInternal InternalProblemReason = "internal"
+	InternalProblemReasonInternal             InternalProblemReason = "internal"
+	InternalProblemReasonCommitOutcomeUnknown InternalProblemReason = "commit_outcome_unknown"
+	InternalProblemReasonCatalogCorrupt       InternalProblemReason = "catalog_corrupt"
+	InternalProblemReasonCatalogSchemaDrift   InternalProblemReason = "catalog_schema_drift"
+	InternalProblemReasonStorageUnavailable   InternalProblemReason = "storage_unavailable"
 )
 
 // AllValues returns all InternalProblemReason values.
 func (InternalProblemReason) AllValues() []InternalProblemReason {
 	return []InternalProblemReason{
 		InternalProblemReasonInternal,
+		InternalProblemReasonCommitOutcomeUnknown,
+		InternalProblemReasonCatalogCorrupt,
+		InternalProblemReasonCatalogSchemaDrift,
+		InternalProblemReasonStorageUnavailable,
 	}
 }
 
@@ -1411,6 +1430,14 @@ func (InternalProblemReason) AllValues() []InternalProblemReason {
 func (s InternalProblemReason) MarshalText() ([]byte, error) {
 	switch s {
 	case InternalProblemReasonInternal:
+		return []byte(s), nil
+	case InternalProblemReasonCommitOutcomeUnknown:
+		return []byte(s), nil
+	case InternalProblemReasonCatalogCorrupt:
+		return []byte(s), nil
+	case InternalProblemReasonCatalogSchemaDrift:
+		return []byte(s), nil
+	case InternalProblemReasonStorageUnavailable:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -1422,6 +1449,18 @@ func (s *InternalProblemReason) UnmarshalText(data []byte) error {
 	switch InternalProblemReason(data) {
 	case InternalProblemReasonInternal:
 		*s = InternalProblemReasonInternal
+		return nil
+	case InternalProblemReasonCommitOutcomeUnknown:
+		*s = InternalProblemReasonCommitOutcomeUnknown
+		return nil
+	case InternalProblemReasonCatalogCorrupt:
+		*s = InternalProblemReasonCatalogCorrupt
+		return nil
+	case InternalProblemReasonCatalogSchemaDrift:
+		*s = InternalProblemReasonCatalogSchemaDrift
+		return nil
+	case InternalProblemReasonStorageUnavailable:
+		*s = InternalProblemReasonStorageUnavailable
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)
@@ -2560,6 +2599,52 @@ func (o OptProblemLocation) Get() (v ProblemLocation, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptProblemLocation) Or(d ProblemLocation) ProblemLocation {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptProblemStage returns new OptProblemStage with value set to v.
+func NewOptProblemStage(v ProblemStage) OptProblemStage {
+	return OptProblemStage{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptProblemStage is optional ProblemStage.
+type OptProblemStage struct {
+	Value ProblemStage
+	Set   bool
+}
+
+// IsSet returns true if OptProblemStage was set.
+func (o OptProblemStage) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptProblemStage) Reset() {
+	var v ProblemStage
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptProblemStage) SetTo(v ProblemStage) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptProblemStage) Get() (v ProblemStage, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptProblemStage) Or(d ProblemStage) ProblemStage {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/clients/go/api/oas/oas_validators_gen.go
+++ b/clients/go/api/oas/oas_validators_gen.go
@@ -729,6 +729,29 @@ func (s *InternalProblem) Validate() error {
 		})
 	}
 	if err := func() error {
+		if err := (validate.String{
+			MinLength:     1,
+			MinLengthSet:  true,
+			MaxLength:     0,
+			MaxLengthSet:  false,
+			Email:         false,
+			Hostname:      false,
+			Regex:         nil,
+			MinNumeric:    0,
+			MinNumericSet: false,
+			MaxNumeric:    0,
+			MaxNumericSet: false,
+		}).Validate(string(s.Detail)); err != nil {
+			return errors.Wrap(err, "string")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "detail",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if err := s.Reason.Validate(); err != nil {
 			return err
 		}
@@ -750,6 +773,24 @@ func (s *InternalProblem) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.Stage.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "stage",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -768,6 +809,14 @@ func (s InternalProblemCode) Validate() error {
 func (s InternalProblemReason) Validate() error {
 	switch s {
 	case "internal":
+		return nil
+	case "commit_outcome_unknown":
+		return nil
+	case "catalog_corrupt":
+		return nil
+	case "catalog_schema_drift":
+		return nil
+	case "storage_unavailable":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)

--- a/clients/go/api/problem_convert.go
+++ b/clients/go/api/problem_convert.go
@@ -15,6 +15,10 @@ func ProblemToOAS(p protocol.Problem) oas.Problem {
 	if stage == "" {
 		stage = oas.ProblemStage(protocol.ProblemStagePreflight)
 	}
+	internalStage := oas.OptProblemStage{}
+	if p.Stage != "" {
+		internalStage = oas.NewOptProblemStage(oas.ProblemStage(p.Stage))
+	}
 	switch p.Code {
 	case protocol.CodeExecutionFailed:
 		return oas.NewExecutionFailedProblemProblem(oas.ExecutionFailedProblem{
@@ -51,9 +55,10 @@ func ProblemToOAS(p protocol.Problem) oas.Problem {
 			Type:   oas.InternalProblemTypeUrnRadProblemInternal,
 			Title:  oas.InternalProblemTitleInternalServerError,
 			Status: oas.InternalProblemStatus500,
-			Detail: oas.NewOptString("internal error"),
-			Reason: oas.InternalProblemReasonInternal,
+			Detail: p.Detail,
+			Reason: oas.InternalProblemReason(p.Reason),
 			Code:   oas.InternalProblemCodeInternal,
+			Stage:  internalStage,
 		})
 	default:
 		return oas.NewInvalidProblemProblem(oas.InvalidProblem{
@@ -92,8 +97,8 @@ func ProblemFromOAS(o oas.Problem) protocol.Problem {
 	case oas.InternalProblemProblem:
 		p := o.InternalProblem
 		return problemFromFields(
-			string(p.Type), string(p.Title), int(p.Status), p.Detail.Or(""),
-			string(p.Code), string(p.Reason), "",
+			string(p.Type), string(p.Title), int(p.Status), p.Detail,
+			string(p.Code), string(p.Reason), string(p.Stage.Or("")),
 		)
 	default:
 		p := o.InvalidProblem

--- a/clients/go/api/problem_convert_test.go
+++ b/clients/go/api/problem_convert_test.go
@@ -28,15 +28,6 @@ func TestProblemConversionUsesTheCodeDiscriminatedUnion(t *testing.T) {
 				t.Fatalf("union kind = %q, want %q", generated.Type, test.kind)
 			}
 			roundTrip := ProblemFromOAS(generated)
-			if test.code == protocol.CodeInternal {
-				if roundTrip.Reason != protocol.CodeInternal {
-					t.Fatalf("internal reason = %q, want redacted %q", roundTrip.Reason, protocol.CodeInternal)
-				}
-				if roundTrip.Detail != "internal error" {
-					t.Fatalf("internal detail = %q, want redacted detail", roundTrip.Detail)
-				}
-				return
-			}
 			if roundTrip != problem {
 				t.Fatalf("round trip = %#v, want %#v", roundTrip, problem)
 			}

--- a/home/content/docs/reference/http-api.mdx
+++ b/home/content/docs/reference/http-api.mdx
@@ -781,9 +781,9 @@ One secondary index, in both definitions and introspection.
 
 #### `InternalProblem`
 
-A deliberately impoverished internal failure. Wrapped causes,
-locations, execution context, catalog identity, keys, and values are
-never exposed. `incident` is an optional opaque log correlation ID.
+A database failure that prevents the operation from completing. The
+detail contains the complete available diagnostic, including wrapped
+causes. `incident` correlates the response with the server log.
 
 #### `InvalidDiagnostic`
 

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -221,7 +221,7 @@ impl ApiError {
             Problem::InternalProblem(problem) => (
                 "internal",
                 problem.reason.as_str(),
-                problem.detail.as_deref(),
+                Some(problem.detail.as_str()),
             ),
         }
     }

--- a/src/engine/01_kv/slatedb/mod.rs
+++ b/src/engine/01_kv/slatedb/mod.rs
@@ -570,7 +570,7 @@ impl Kv for ReaderStore {
 impl TransactionalKv for ReaderStore {
     async fn begin(&self, _isolation: IsolationLevel) -> Result<Box<dyn Transaction>> {
         let lease = self.lifecycle.acquire()?;
-        let snapshot = ReaderSnapshot::new(self.reader.current(), self.reader.scan_tuning);
+        let snapshot = ReaderSnapshot::new(Arc::clone(&self.reader));
         let begin_position = DataPosition::from_sequence(snapshot.durable_sequence);
         Ok(Box::new(ReaderTransaction {
             snapshot,
@@ -640,15 +640,19 @@ struct ReaderTransaction {
 
 #[derive(Clone)]
 struct ReaderSnapshot {
+    backend: Arc<ReaderBackend>,
     reader: Arc<slate_db::DbReader>,
     durable_sequence: u64,
     scan_tuning: ScanTuning,
 }
 
 impl ReaderSnapshot {
-    fn new(reader: Arc<slate_db::DbReader>, scan_tuning: ScanTuning) -> Self {
+    fn new(backend: Arc<ReaderBackend>) -> Self {
+        let reader = backend.current();
         let durable_sequence = reader.status().durable_seq;
+        let scan_tuning = backend.scan_tuning;
         Self {
+            backend,
             reader,
             durable_sequence,
             scan_tuning,
@@ -668,22 +672,45 @@ impl ReaderSnapshot {
 
     async fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
         self.validate()?;
-        let result = self.reader.get(key).await;
-        self.validate()?;
-        result.map_err(map_operation_error)
+        match self.reader.get(key).await {
+            Ok(value) => {
+                self.validate()?;
+                Ok(value)
+            }
+            Err(error) => Err(self.operation_error(error).await),
+        }
     }
 
     async fn scan(&self, request: &ScanRequest) -> Result<slate_db::DbIterator> {
         self.validate()?;
-        let result = self
+        match self
             .reader
             .scan_with_options(
                 request.range.clone(),
                 &scan_options(request, self.scan_tuning),
             )
-            .await;
-        self.validate()?;
-        result.map_err(map_operation_error)
+            .await
+        {
+            Ok(iterator) => {
+                self.validate()?;
+                Ok(iterator)
+            }
+            Err(error) => Err(self.operation_error(error).await),
+        }
+    }
+
+    async fn operation_error(&self, error: slate_db::Error) -> Error {
+        if !reader_must_reopen(&error) {
+            return map_operation_error(error);
+        }
+        match self.backend.reopen_after(&self.reader).await {
+            Ok(_) => Error::source(
+                ErrorKind::Conflict,
+                "reader snapshot became unavailable during the transaction",
+                error,
+            ),
+            Err(error) => map_operation_error(error),
+        }
     }
 }
 
@@ -720,9 +747,9 @@ impl Transaction for ReaderTransaction {
     ) -> Result<Box<dyn KvIterator + 'a>> {
         let request = ScanRequest::access_path(range).with_order(order);
         let iterator = self.snapshot.scan(&request).await?;
-        Ok(Box::new(SlateIterator {
+        Ok(Box::new(ReaderSlateIterator {
             iterator,
-            _lease: None,
+            snapshot: self.snapshot.clone(),
         }))
     }
 
@@ -731,9 +758,9 @@ impl Transaction for ReaderTransaction {
         request: ScanRequest,
     ) -> Result<Box<dyn KvIterator + 'a>> {
         let iterator = self.snapshot.scan(&request).await?;
-        Ok(Box::new(SlateIterator {
+        Ok(Box::new(ReaderSlateIterator {
             iterator,
-            _lease: None,
+            snapshot: self.snapshot.clone(),
         }))
     }
 
@@ -849,6 +876,46 @@ struct SlateIterator {
     _lease: Option<Lease>,
 }
 
+struct ReaderSlateIterator {
+    iterator: slate_db::DbIterator,
+    snapshot: ReaderSnapshot,
+}
+
+#[async_trait]
+impl KvIterator for ReaderSlateIterator {
+    async fn seek_forward(&mut self, next_key: &[u8]) -> Result<()> {
+        match self.iterator.seek(next_key).await {
+            Ok(()) => Ok(()),
+            Err(error) => Err(self.snapshot.operation_error(error).await),
+        }
+    }
+
+    async fn next(&mut self) -> Result<Option<Entry>> {
+        match self.iterator.next().await {
+            Ok(entry) => Ok(entry.map(slate_entry)),
+            Err(error) => Err(self.snapshot.operation_error(error).await),
+        }
+    }
+
+    async fn next_batch(&mut self, limit: usize, output: &mut Vec<Entry>) -> Result<()> {
+        let target = output.len().saturating_add(limit);
+        while output.len() < target {
+            let Some(entry) = self.next().await? else {
+                break;
+            };
+            output.push(entry);
+        }
+        Ok(())
+    }
+}
+
+fn slate_entry(entry: slate_db::KeyValue) -> Entry {
+    Entry {
+        key: entry.key,
+        value: entry.value,
+    }
+}
+
 #[async_trait]
 impl KvIterator for SlateIterator {
     async fn seek_forward(&mut self, next_key: &[u8]) -> Result<()> {
@@ -861,12 +928,7 @@ impl KvIterator for SlateIterator {
     async fn next(&mut self) -> Result<Option<Entry>> {
         let result = self.iterator.next().await;
         result
-            .map(|entry| {
-                entry.map(|entry| Entry {
-                    key: entry.key,
-                    value: entry.value,
-                })
-            })
+            .map(|entry| entry.map(slate_entry))
             .map_err(map_operation_error)
     }
 
@@ -1830,6 +1892,38 @@ mod tests {
         assert_eq!(entries[0].key, Bytes::from_static(b"key"));
         assert_eq!(entries[0].value, Bytes::from_static(b"value"));
 
+        reader.close().await?;
+        writer.close().await
+    }
+
+    #[tokio::test]
+    async fn reader_snapshot_reopens_a_missing_checkpoint_as_a_conflict() -> Result<()> {
+        let objects: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let writer = Store::open("reader-snapshot-reopen", Arc::clone(&objects)).await?;
+        writer
+            .put(Bytes::from_static(b"key"), Bytes::from_static(b"value"))
+            .await?;
+        let reader = ReaderStore::open(
+            "reader-snapshot-reopen",
+            objects,
+            Duration::from_millis(100),
+        )
+        .await?;
+        let failed = reader.reader.current();
+        let snapshot = ReaderSnapshot::new(Arc::clone(&reader.reader));
+
+        let error = snapshot
+            .operation_error(slate_db::Error::data(
+                "checkpoint missing during refresh".into(),
+            ))
+            .await;
+
+        assert_eq!(error.kind(), ErrorKind::Conflict);
+        assert!(!Arc::ptr_eq(&failed, &reader.reader.current()));
+        assert_eq!(
+            reader.get(b"key").await?,
+            Some(Bytes::from_static(b"value"))
+        );
         reader.close().await?;
         writer.close().await
     }

--- a/src/engine/04_planner/error.rs
+++ b/src/engine/04_planner/error.rs
@@ -37,6 +37,7 @@ impl Reason {
 #[error("{message}")]
 pub struct Error {
     reason: Reason,
+    catalog_kind: Option<crate::engine::catalog::ErrorKind>,
     message: String,
     #[source]
     source: Option<Box<dyn StdError + Send + Sync>>,
@@ -47,6 +48,7 @@ impl Error {
         debug_assert_ne!(reason, Reason::Catalog);
         Self {
             reason,
+            catalog_kind: None,
             message: message.into(),
             source: None,
         }
@@ -60,6 +62,10 @@ impl Error {
         self.reason.class()
     }
 
+    pub fn catalog_kind(&self) -> Option<crate::engine::catalog::ErrorKind> {
+        self.catalog_kind
+    }
+
     pub(crate) fn context(mut self, context: impl AsRef<str>) -> Self {
         self.message = format!("{}: {}", context.as_ref(), self.message);
         self
@@ -68,8 +74,10 @@ impl Error {
 
 impl From<crate::engine::catalog::Error> for Error {
     fn from(error: crate::engine::catalog::Error) -> Self {
+        let catalog_kind = error.kind();
         Self {
             reason: Reason::Catalog,
+            catalog_kind: Some(catalog_kind),
             message: format!("planner catalog: {error}"),
             source: Some(Box::new(error)),
         }

--- a/src/engine/05_exec/error.rs
+++ b/src/engine/05_exec/error.rs
@@ -236,37 +236,7 @@ impl From<crate::engine::kv::Error> for Error {
 
 impl From<crate::engine::catalog::Error> for Error {
     fn from(error: crate::engine::catalog::Error) -> Self {
-        let (kind, reason) = match error.kind() {
-            crate::engine::catalog::ErrorKind::InvalidInput
-            | crate::engine::catalog::ErrorKind::NotFound => {
-                (ErrorKind::InvalidInput, ErrorReason::Invalid)
-            }
-            crate::engine::catalog::ErrorKind::AlreadyExists => (
-                ErrorKind::ConstraintViolation,
-                ErrorReason::ConstraintViolation,
-            ),
-            crate::engine::catalog::ErrorKind::Conflict => {
-                (ErrorKind::Conflict, ErrorReason::SerializableConflict)
-            }
-            crate::engine::catalog::ErrorKind::TransitionBackpressure => (
-                ErrorKind::TransitionBackpressure,
-                ErrorReason::SchemaTransitionBackpressure,
-            ),
-            crate::engine::catalog::ErrorKind::CommitOutcomeUnknown => (
-                ErrorKind::CommitOutcomeUnknown,
-                ErrorReason::CommitOutcomeUnknown,
-            ),
-            crate::engine::catalog::ErrorKind::CatalogCorrupt
-            | crate::engine::catalog::ErrorKind::CatalogDrift => (
-                ErrorKind::CorruptData,
-                if error.kind() == crate::engine::catalog::ErrorKind::CatalogDrift {
-                    ErrorReason::CatalogSchemaDrift
-                } else {
-                    ErrorReason::CatalogCorrupt
-                },
-            ),
-            _ => (ErrorKind::Storage, ErrorReason::StorageUnavailable),
-        };
+        let (kind, reason) = catalog_error_class(error.kind());
         Self::source_with_reason(kind, reason, format!("exec catalog: {error}"), error)
     }
 }
@@ -293,12 +263,50 @@ impl From<crate::engine::lir::eval::EvalError> for Error {
 
 impl From<crate::engine::planner::Error> for Error {
     fn from(error: crate::engine::planner::Error) -> Self {
-        let kind = match error.class() {
-            crate::engine::planner::ErrorClass::Invalid => ErrorKind::InvalidInput,
-            crate::engine::planner::ErrorClass::Internal => ErrorKind::Internal,
+        let (kind, reason) = match error.catalog_kind() {
+            Some(kind) => catalog_error_class(kind),
+            None => {
+                let kind = match error.class() {
+                    crate::engine::planner::ErrorClass::Invalid => ErrorKind::InvalidInput,
+                    crate::engine::planner::ErrorClass::Internal => ErrorKind::Internal,
+                };
+                (kind, planner_reason(error.reason()))
+            }
         };
-        let reason = planner_reason(error.reason());
         Self::source_with_reason(kind, reason, error.to_string(), error)
+    }
+}
+
+fn catalog_error_class(kind: crate::engine::catalog::ErrorKind) -> (ErrorKind, ErrorReason) {
+    match kind {
+        crate::engine::catalog::ErrorKind::InvalidInput
+        | crate::engine::catalog::ErrorKind::NotFound => {
+            (ErrorKind::InvalidInput, ErrorReason::Invalid)
+        }
+        crate::engine::catalog::ErrorKind::AlreadyExists => (
+            ErrorKind::ConstraintViolation,
+            ErrorReason::ConstraintViolation,
+        ),
+        crate::engine::catalog::ErrorKind::Conflict => {
+            (ErrorKind::Conflict, ErrorReason::SerializableConflict)
+        }
+        crate::engine::catalog::ErrorKind::TransitionBackpressure => (
+            ErrorKind::TransitionBackpressure,
+            ErrorReason::SchemaTransitionBackpressure,
+        ),
+        crate::engine::catalog::ErrorKind::CommitOutcomeUnknown => (
+            ErrorKind::CommitOutcomeUnknown,
+            ErrorReason::CommitOutcomeUnknown,
+        ),
+        crate::engine::catalog::ErrorKind::CatalogCorrupt => {
+            (ErrorKind::CorruptData, ErrorReason::CatalogCorrupt)
+        }
+        crate::engine::catalog::ErrorKind::CatalogDrift => {
+            (ErrorKind::CorruptData, ErrorReason::CatalogSchemaDrift)
+        }
+        crate::engine::catalog::ErrorKind::Storage => {
+            (ErrorKind::Storage, ErrorReason::StorageUnavailable)
+        }
     }
 }
 
@@ -371,5 +379,17 @@ mod tests {
         }
         assert!(!Error::message(ErrorKind::InvalidInput, "fix it").is_conflict());
         assert!(!Error::message(ErrorKind::CommitOutcomeUnknown, "reconcile first").is_conflict());
+    }
+
+    #[test]
+    fn planner_catalog_conflict_keeps_the_retryable_class() {
+        let catalog = crate::engine::catalog::Error::message(
+            crate::engine::catalog::ErrorKind::Conflict,
+            "reader snapshot changed during the transaction",
+        );
+        let planner = crate::engine::planner::Error::from(catalog);
+        let error = Error::from(planner);
+        assert_eq!(error.kind(), ErrorKind::Conflict);
+        assert_eq!(error.reason(), ErrorReason::SerializableConflict);
     }
 }

--- a/src/http/generated/types.rs
+++ b/src/http/generated/types.rs
@@ -1387,19 +1387,21 @@ pub struct InvalidDiagnostic {
     pub location: Option<ProblemLocation>,
     pub reason: String,
 }
-/**A deliberately impoverished internal failure. Wrapped causes,
-locations, execution context, catalog identity, keys, and values are
-never exposed. `incident` is an optional opaque log correlation ID.
+/**A database failure that prevents the operation from completing. The
+detail contains the complete available diagnostic, including wrapped
+causes. `incident` correlates the response with the server log.
 */
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct InternalProblem {
-    ///A human readable explanation specific to this occurrence.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<String>,
-    ///An opaque identifier correlated with server-side diagnostics.
+    ///The complete available diagnostic for this failure.
+    ///Constraint: minLength=1
+    pub detail: String,
+    ///An identifier correlated with the server log.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub incident: Option<String>,
     pub reason: InternalProblemReason,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stage: Option<ProblemStage>,
     pub status: i64,
     pub title: InternalProblemTitle,
     pub r#type: InternalProblemType,
@@ -1455,11 +1457,23 @@ pub enum InternalProblemReason {
     #[default]
     #[serde(rename = "internal")]
     Internal,
+    #[serde(rename = "commit_outcome_unknown")]
+    CommitOutcomeUnknown,
+    #[serde(rename = "catalog_corrupt")]
+    CatalogCorrupt,
+    #[serde(rename = "catalog_schema_drift")]
+    CatalogSchemaDrift,
+    #[serde(rename = "storage_unavailable")]
+    StorageUnavailable,
 }
 impl InternalProblemReason {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Internal => "internal",
+            Self::CommitOutcomeUnknown => "commit_outcome_unknown",
+            Self::CatalogCorrupt => "catalog_corrupt",
+            Self::CatalogSchemaDrift => "catalog_schema_drift",
+            Self::StorageUnavailable => "storage_unavailable",
         }
     }
 }

--- a/src/http/problem.rs
+++ b/src/http/problem.rs
@@ -117,22 +117,84 @@ impl ResponseProblem {
         }
     }
 
-    fn internal(_failure: InternalFailure) -> Self {
-        Self::internal_transport()
-    }
-
-    pub(super) fn internal_transport() -> Self {
+    fn internal(failure: InternalFailure) -> Self {
+        let context = crate::logging::request_context();
+        let incident = (!context.request_id.is_empty()).then_some(context.request_id);
+        let detail = failure.diagnostic().to_owned();
+        tracing::error!(
+            target: "rad",
+            event = "http.internal_error",
+            component = "http",
+            incident = incident.as_deref().unwrap_or_default(),
+            trace_id = context.trace_id,
+            span_id = context.span_id,
+            error_kind = failure.kind().as_str(),
+            error_reason = failure.reason().as_str(),
+            error_stage = ?failure.stage,
+            diagnostic = failure.diagnostic(),
+            message = "HTTP request failed because of an internal error"
+        );
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             body: wire::Problem::InternalProblem(wire::InternalProblem {
-                detail: Some("internal error".into()),
-                incident: None,
-                reason: wire::InternalProblemReason::Internal,
+                detail,
+                incident,
+                reason: internal_reason(failure.reason()),
+                stage: Some(stage(failure.stage)),
                 status: 500,
                 title: wire::InternalProblemTitle::InternalServerError,
                 r#type: wire::InternalProblemType::UrnRadProblemInternal,
             }),
         }
+    }
+
+    pub(super) fn internal_transport(detail: impl Into<String>) -> Self {
+        let detail = detail.into();
+        let context = crate::logging::request_context();
+        let incident = (!context.request_id.is_empty()).then_some(context.request_id);
+        tracing::error!(
+            target: "rad",
+            event = "http.internal_error",
+            component = "http",
+            incident = incident.as_deref().unwrap_or_default(),
+            trace_id = context.trace_id,
+            span_id = context.span_id,
+            error_kind = "internal",
+            error_reason = "internal",
+            diagnostic = detail,
+            message = "HTTP request failed because of an internal error"
+        );
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            body: wire::Problem::InternalProblem(wire::InternalProblem {
+                detail,
+                incident,
+                reason: wire::InternalProblemReason::Internal,
+                stage: None,
+                status: 500,
+                title: wire::InternalProblemTitle::InternalServerError,
+                r#type: wire::InternalProblemType::UrnRadProblemInternal,
+            }),
+        }
+    }
+}
+
+fn internal_reason(value: crate::engine::exec::ErrorReason) -> wire::InternalProblemReason {
+    match value {
+        crate::engine::exec::ErrorReason::CommitOutcomeUnknown => {
+            wire::InternalProblemReason::CommitOutcomeUnknown
+        }
+        crate::engine::exec::ErrorReason::CatalogCorrupt => {
+            wire::InternalProblemReason::CatalogCorrupt
+        }
+        crate::engine::exec::ErrorReason::CatalogSchemaDrift => {
+            wire::InternalProblemReason::CatalogSchemaDrift
+        }
+        crate::engine::exec::ErrorReason::StorageUnavailable => {
+            wire::InternalProblemReason::StorageUnavailable
+        }
+        crate::engine::exec::ErrorReason::Internal => wire::InternalProblemReason::Internal,
+        _ => unreachable!("non-internal reason reached the internal problem mapper"),
     }
 }
 
@@ -315,9 +377,9 @@ mod tests {
         assert_eq!(internal.status, StatusCode::INTERNAL_SERVER_ERROR);
         let value = serde_json::to_value(internal.body).unwrap();
         assert_eq!(value["code"], "internal");
-        assert_eq!(value["reason"], "internal");
-        assert_eq!(value["detail"], "internal error");
-        assert!(!value.to_string().contains("secret storage"));
+        assert_eq!(value["reason"], "storage_unavailable");
+        assert_eq!(value["stage"], "storage");
+        assert_eq!(value["detail"], "secret storage implementation detail");
 
         let malformed = ResponseProblem::invalid(
             InvalidFailure {

--- a/src/http/tests.rs
+++ b/src/http/tests.rs
@@ -540,7 +540,7 @@ async fn storage_conflict_is_a_typed_retryable_problem_outside_in() {
 }
 
 #[tokio::test]
-async fn internal_storage_failure_is_redacted_outside_in() {
+async fn internal_storage_failure_is_diagnostic_outside_in() {
     let response = fault_router("http-internal", Operation::Begin, KvErrorKind::Internal)
         .await
         .oneshot(post_json("/execute", one_row_program()))
@@ -555,12 +555,20 @@ async fn internal_storage_failure_is_redacted_outside_in() {
     let body = json_body(response).await;
     assert_eq!(body["type"], "urn:rad:problem:internal");
     assert_eq!(body["code"], "internal");
-    assert_eq!(body["reason"], "internal");
+    assert_eq!(body["reason"], "storage_unavailable");
+    assert_eq!(body["stage"], "storage");
     assert_eq!(body["status"], 500);
-    assert_eq!(body["detail"], "internal error");
+    assert_eq!(
+        body["detail"],
+        "exec storage: fault injection: Begin returned Internal"
+    );
+    assert!(
+        body["incident"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+    );
     assert!(body.get("execution").is_none());
     assert!(body.get("conflict").is_none());
-    assert!(!body.to_string().contains("injected"));
 }
 
 #[tokio::test]

--- a/src/http/validation.rs
+++ b/src/http/validation.rs
@@ -19,8 +19,13 @@ pub(super) async fn normalize_generated_rejection(response: Response) -> Respons
 
     let status = response.status();
     let (parts, body) = response.into_parts();
-    let Ok(bytes) = to_bytes(body, MAX_GENERATED_PROBLEM_BYTES).await else {
-        return render(ResponseProblem::internal_transport());
+    let bytes = match to_bytes(body, MAX_GENERATED_PROBLEM_BYTES).await {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            return render(ResponseProblem::internal_transport(format!(
+                "failed to read the generated HTTP error response: {error}"
+            )));
+        }
     };
     let Ok(problem) = serde_json::from_slice::<ProblemDetails>(&bytes) else {
         return Response::from_parts(parts, Body::from(bytes));
@@ -32,7 +37,10 @@ pub(super) async fn normalize_generated_rejection(response: Response) -> Respons
         return Response::from_parts(parts, Body::from(bytes));
     }
     if status.is_server_error() {
-        return render(ResponseProblem::internal_transport());
+        return render(ResponseProblem::internal_transport(format!(
+            "generated HTTP contract failure: {}",
+            problem.title
+        )));
     }
 
     let location = problem.errors.first().map(|error| Location {

--- a/src/service/error.rs
+++ b/src/service/error.rs
@@ -223,10 +223,20 @@ pub struct NotFoundFailure {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InternalFailure {
     pub stage: Stage,
+    kind: crate::engine::exec::ErrorKind,
+    reason: crate::engine::exec::ErrorReason,
     diagnostic: String,
 }
 
 impl InternalFailure {
+    pub fn kind(&self) -> crate::engine::exec::ErrorKind {
+        self.kind
+    }
+
+    pub fn reason(&self) -> crate::engine::exec::ErrorReason {
+        self.reason
+    }
+
     pub fn diagnostic(&self) -> &str {
         &self.diagnostic
     }
@@ -323,7 +333,9 @@ impl Failure {
             | ErrorReason::StorageUnavailable
             | ErrorReason::Internal => Self::Internal(InternalFailure {
                 stage,
-                diagnostic: detail,
+                kind: error.kind(),
+                reason: error.reason(),
+                diagnostic: error_diagnostic(error),
             }),
         }
     }
@@ -341,6 +353,20 @@ impl Failure {
             resource,
         })
     }
+}
+
+fn error_diagnostic(error: &Error) -> String {
+    let mut diagnostic = error.to_string();
+    let mut source = std::error::Error::source(error);
+    while let Some(error) = source {
+        let detail = error.to_string();
+        if !diagnostic.ends_with(&detail) {
+            diagnostic.push_str(": ");
+            diagnostic.push_str(&detail);
+        }
+        source = error.source();
+    }
+    diagnostic
 }
 
 impl From<&Error> for Failure {
@@ -471,5 +497,19 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn internal_diagnostic_includes_the_source_chain() {
+        let error = exec::Error::source_with_reason(
+            exec::ErrorKind::Storage,
+            exec::ErrorReason::StorageUnavailable,
+            "read object",
+            std::io::Error::other("connection closed"),
+        );
+        let Failure::Internal(failure) = Failure::from_exec(&error) else {
+            panic!("storage failure did not map to an internal failure");
+        };
+        assert_eq!(failure.diagnostic(), "read object: connection closed");
     }
 }

--- a/src/service/error.rs
+++ b/src/service/error.rs
@@ -224,7 +224,7 @@ pub struct NotFoundFailure {
 pub struct InternalFailure {
     pub stage: Stage,
     kind: crate::engine::exec::ErrorKind,
-    reason: crate::engine::exec::ErrorReason,
+    reason: ErrorReason,
     diagnostic: String,
 }
 
@@ -233,7 +233,7 @@ impl InternalFailure {
         self.kind
     }
 
-    pub fn reason(&self) -> crate::engine::exec::ErrorReason {
+    pub fn reason(&self) -> ErrorReason {
         self.reason
     }
 


### PR DESCRIPTION
## Summary

- Reopen a SlateDB reader when its transaction checkpoint becomes unavailable.
- Return a retryable snapshot conflict after the reader reopens.
- Return the complete internal error diagnostic, stable reason, engine stage, and incident ID.
- Preserve internal error information in the Rust CLI and Go client.
- Update the OpenAPI contract and generated documentation.

## CI investigation

The x86_64 and aarch64 RustFS jobs failed in the same S3 multi-replica test. A reader transaction bypassed the existing reader reopen path. A missing checkpoint was therefore returned as HTTP 500. The successful pull request run and the failed merge run used the same source tree, which indicates a timing-dependent failure.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets`
- `go test ./...`
- `go test ./clients/go/api/...`
- `task check:http`
- S3 multi-replica test with RustFS